### PR TITLE
Updated the version of imagegallery lib for Android

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -6,5 +6,5 @@ android {
     }
 }
 dependencies {
-  compile 'com.github.lawloretienne:imagegallery:0.0.13'
+  compile 'com.github.lawloretienne:imagegallery:0.0.15'
 }


### PR DESCRIPTION
New version uses up-to-date Support library and this avoids class collisions with other plugins.
