### PR TITLE
remove android:label from AndroidManifest.xml

### DIFF
--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <activity  
         android:name="com.etiennelawlor.imagegallery.library.activities.ImageGalleryActivity"
         android:configChanges="orientation|keyboardHidden|screenSize"
-        android:label=""
         android:theme="@style/ImageGalleryTheme" />
   </application>
 


### PR DESCRIPTION
It make issues on NativeScript version 5
you can't replace android:label in App/AndroidManifest.xml because your plugin used it