### PR TITLE
Issue #26 - iOS Gallery Fix

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -2,8 +2,8 @@ var frameModule = require("ui/frame");
 
 PhotoViewer.prototype.showViewer = function(imagesArray) {
     var photosArray = new java.util.ArrayList();
-    
-    imagesArray.forEach(function(imgUrl){         
+
+    imagesArray.forEach(function(imgUrl){
         photosArray.add(imgUrl);
     });
 
@@ -13,17 +13,17 @@ PhotoViewer.prototype.showViewer = function(imagesArray) {
     var activity = frameModule.topmost().android.activity;
 
     if(!showAlbum)
-        _android = new android.content.Intent(activity, com.etiennelawlor.imagegallery.library.activities.FullScreenImageGalleryActivity.class);
+        this._android = new android.content.Intent(activity, com.etiennelawlor.imagegallery.library.activities.FullScreenImageGalleryActivity.class);
     else
-        _android = new android.content.Intent(activity, com.etiennelawlor.imagegallery.library.activities.ImageGalleryActivity.class);
+        this._android = new android.content.Intent(activity, com.etiennelawlor.imagegallery.library.activities.ImageGalleryActivity.class);
 
-    _android.putStringArrayListExtra("images", photosArray);
-    _android.putExtra("position", startIndex);
+    this._android.putStringArrayListExtra("images", photosArray);
+    this._android.putExtra("position", startIndex);
 
     if(paletteType)
-        _android.putExtra("palette_color_type", getPaletteType(paletteType));
-    
-    activity.startActivity(_android);
+        this._android.putExtra("palette_color_type", getPaletteType(paletteType));
+
+    activity.startActivity(this._android);
 };
 
 function getPaletteType(paletteType){
@@ -95,7 +95,7 @@ function PhotoViewer() {
         configurable: true
     });
 
-    if (!this instanceof PhotoViewer) { 
+    if (!this instanceof PhotoViewer) {
         return new PhotoViewer();
     }
 };

--- a/index.ios.js
+++ b/index.ios.js
@@ -12,7 +12,7 @@ PhotoViewer.prototype.showViewer = function(imagesArray) {
 
     imagesArray.forEach(function(imageItem) {
         var nytImage = NYTImage.alloc().init();
-        
+
         if(typeof imageItem === 'object' && (imageItem instanceof NSObject && imageItem.conformsToProtocol(NYTPhoto))){
             //console.log('imageItem is of type NYTImage: ' + imageItem.conformsToProtocol(NYTPhoto));
             nytImage = imageItem;
@@ -26,12 +26,12 @@ PhotoViewer.prototype.showViewer = function(imagesArray) {
             var titleColor = that._titleColor || new colorModule.Color("white").ios;
             var summaryColor = that._summaryColor || new colorModule.Color("lightgray").ios;
             var creditColor = that._creditColor || new colorModule.Color("gray").ios;
-	        
+
             if(imageItem.imageURL)
                 nytImage.image = imageFromURL(imageItem.imageURL);
             else
                 nytImage.image = imageItem.image;
-            
+
             nytImage.attributedCaptionTitle = attributedString(imageItem.title, titleColor, fontFamily, titleFontSize);
             nytImage.attributedCaptionSummary = attributedString(imageItem.summary, summaryColor, fontFamily, summaryFontSize);
             nytImage.attributedCaptionCredit = attributedString(imageItem.credit, creditColor, fontFamily, creditFontSize);
@@ -44,13 +44,13 @@ PhotoViewer.prototype.showViewer = function(imagesArray) {
         photosArray.addObject(nytImage);
     });
 
-    var dataSource = NYTPhotoViewerArrayDataSource.dataSourceWithPhotos(photosArray);
+    this._iosDatasource = NYTPhotoViewerArrayDataSource.dataSourceWithPhotos(photosArray);
 
     var self = frameModule.topmost().ios;
 
-    var photosViewController = NYTPhotosViewController.alloc().initWithDataSourceInitialPhotoIndexDelegate(dataSource, startIndex, self);
+    var photosViewController = NYTPhotosViewController.alloc().initWithDataSourceInitialPhotoIndexDelegate(this._iosDatasource, startIndex, self);
     frameModule.topmost().viewController.presentViewControllerAnimatedCompletion(photosViewController, true, completionCallback);
-    
+
     this._ios = photosViewController;
 };
 
@@ -153,7 +153,7 @@ function PhotoViewer() {
         configurable: true
     });
 
-    
+
     Object.defineProperty(PhotoViewer.prototype, "titleColor", {
         get: function () {
           return this._titleColor;
@@ -208,7 +208,7 @@ function PhotoViewer() {
     });
 
 
-    if (!this instanceof PhotoViewer) { 
+    if (!this instanceof PhotoViewer) {
         return new PhotoViewer();
     }
 };


### PR DESCRIPTION
The NYTPhotoViewerArrayDataSource instance must be saved on the parent so it remains strong and persists when GC runs. Without saving the dataSource, it is set to nil and the only the single photo is visible.

This fixes issue #26