### PR TITLE
Add showShareButton options for iOS (true by default) : issue #47

### DIFF
--- a/src/photoviewer.d.ts
+++ b/src/photoviewer.d.ts
@@ -60,6 +60,12 @@ export interface PhotoViewerOptions {
         creditColor?: UIColor;
 
         /**
+         * Show share button
+         * Default true  
+         */
+        showShareButton?: boolean;
+
+        /**
          * Optional function to run after the gallery has finished loading images and is visible
          */
         completionCallback?: () => void;

--- a/src/photoviewer.ios.ts
+++ b/src/photoviewer.ios.ts
@@ -69,6 +69,9 @@ export class PhotoViewer implements PhotoViewerBase {
 
         this._dataSource = NYTPhotoViewerArrayDataSource.dataSourceWithPhotos(photosArray);
         const photosViewController = NYTPhotosViewController.alloc().initWithDataSourceInitialPhotoIndexDelegate(this._dataSource, startIndex, null);
+        if(options.ios.showShareButton == false){
+            photosViewController.rightBarButtonItem = null;
+        }
         frame.topmost().ios.controller.presentViewControllerAnimatedCompletion(photosViewController, true, iosCompletionCallback);
 
         return new Promise<void>((resolve) => {


### PR DESCRIPTION
Add an option to remove the share button (only for iOS): 
`showShareButton? : boolean` (true by default)