### PR TITLE
fixes a bug where the showGallery method would lose the correct frame

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -3,11 +3,11 @@
   "description": "A simple Photo-viewer component for NativeScript based on NYTPhotoViewer pod for iOS and ImageGalleryViewer for Android.",
   "main": "photoviewer",
   "typings": "photoviewer.d.ts",
-  "version": "2.1.5",
+  "version": "3.0.0",
   "nativescript": {
     "platforms": {
-      "ios": "3.0.0",
-      "android": "3.0.0"
+      "ios": "6.5.2",
+      "android": "6.5.3"
     },
     "plugin": {
       "nan": "true",
@@ -80,8 +80,8 @@
   "readmeFilename": "README.md",
   "devDependencies": {
     "typescript": "~3.5.3",
-    "tns-core-modules": "~6.0.2",
-    "tns-platform-declarations": "~6.0.2",
+    "@nativescript/core": "~6.5.12",
+    "tns-platform-declarations": "~6.5.12",
     "tslint": "^5.18.0",
     "husky": "^3.0.1",
     "lint-staged": "^9.2.1",

--- a/src/photoviewer.android.ts
+++ b/src/photoviewer.android.ts
@@ -1,4 +1,4 @@
-import * as application from "tns-core-modules/application";
+import * as application from "@nativescript/core/application";
 import { PhotoViewerOptions, PhotoViewer as PhotoViewerBase  } from ".";
 import { PaletteType } from "./photoviewer.common";
 export * from './photoviewer.common';

--- a/src/photoviewer.ios.ts
+++ b/src/photoviewer.ios.ts
@@ -1,8 +1,7 @@
 import { PhotoViewerOptions, NYTPhotoItem, PhotoViewer as PhotoViewerBase } from ".";
-import { Color } from "tns-core-modules/color";
-import { isFileOrResourcePath } from "tns-core-modules/utils/utils";
-import * as imageSource from "tns-core-modules/image-source/image-source";
-import * as frame from "tns-core-modules/ui/frame";
+import { Color } from "@nativescript/core";
+import { fromFileOrResource, isFileOrResourcePath } from "@nativescript/core/image-source";
+import { topmost } from '@nativescript/core/ui/frame';
 
 import { PaletteType } from "./photoviewer.common";
 export * from './photoviewer.common';
@@ -16,7 +15,7 @@ export class PhotoViewer implements PhotoViewerBase {
     private _delegate: PhotoViewerDelegateImpl;
 
     constructor() {
-        rootFrame = frame.Frame.topmost();
+        rootFrame = topmost();
         let photosArray = NSMutableArray.alloc<NYTPhoto>().init();
         _dataSource = new NYTPhotoViewerArrayDataSource({photos: photosArray});
      }
@@ -108,7 +107,7 @@ function getImageData(imageURL: string): NSData {
 function getUIImage(imageURL: string): UIImage {
     if(isFileOrResourcePath(imageURL)){
         console.log("image is file or resource path: ", imageURL);
-        return imageSource.fromFileOrResource(imageURL).ios;
+        return fromFileOrResource(imageURL).ios;
     }
     else{
         console.log("URL: ", imageURL);

--- a/src/photoviewer.ios.ts
+++ b/src/photoviewer.ios.ts
@@ -9,13 +9,14 @@ export * from './photoviewer.common';
 
 declare const NSAttributedString: any;
 var _dataSource: NYTPhotoViewerArrayDataSource;
-
+var rootFrame;
 export class PhotoViewer implements PhotoViewerBase {
 
     public nativeView;
     private _delegate: PhotoViewerDelegateImpl;
 
     constructor() {
+        rootFrame = frame.Frame.topmost();
         let photosArray = NSMutableArray.alloc<NYTPhoto>().init();
         _dataSource = new NYTPhotoViewerArrayDataSource({photos: photosArray});
      }
@@ -80,7 +81,7 @@ export class PhotoViewer implements PhotoViewerBase {
         if(options.ios.showShareButton == false){
             this.nativeView.rightBarButtonItem = null;
         }
-        frame.topmost().ios.controller.presentViewControllerAnimatedCompletion(this.nativeView, true, iosCompletionCallback);
+        rootFrame.ios.controller.presentViewControllerAnimatedCompletion(this.nativeView, true, iosCompletionCallback);
 
         return new Promise<void>((resolve) => {
             this._delegate = PhotoViewerDelegateImpl.initWithResolve(resolve);


### PR DESCRIPTION
In complex apps with several page-router-outlets, the plugin would lose its reference to the correct topmost frame, causing the plugin to not open the gallery after opening it for the first time. Setting a reference in the constructor and using that seems to fix it.
Also fixes a bug where frame.topmost() is depreciated, resulting in a warning. 
And fixed imports to use new barrels. 
I bumped it a whole version because the imports wont work with {N} < 6